### PR TITLE
Add advanced rules and docs

### DIFF
--- a/.cursor/rules/001-base.mdc
+++ b/.cursor/rules/001-base.mdc
@@ -1,10 +1,10 @@
 ---
-description:
+description: "001: base rule"
 globs:
 alwaysApply: false
 ---
 ---
-description: Global coding conventions & context order
+description: "001: Global coding conventions & context order"
 globs: ["**/*.py", "**/*.ts"]
 alwaysApply: true
 ---

--- a/.cursor/rules/010-checklist.mdc
+++ b/.cursor/rules/010-checklist.mdc
@@ -1,5 +1,5 @@
 ---
-description: Keep DEV_CHECKLIST.md up-to-date
+description: "010: Keep DEV_CHECKLIST.md up-to-date"
 scopes: [chat, edit]
 tags: [workflow, documentation]
 priority: 10

--- a/.cursor/rules/020-safety.mdc
+++ b/.cursor/rules/020-safety.mdc
@@ -1,5 +1,5 @@
 ---
-description: Hallucination guardrails & file-by-file editing
+description: "020: Hallucination guardrails & file-by-file editing"
 scopes: [chat, edit]
 tags: [safety, guardrails]
 priority: 20

--- a/.cursor/rules/030-test-driven.mdc
+++ b/.cursor/rules/030-test-driven.mdc
@@ -1,5 +1,5 @@
 ---
-description: Write failing tests first, then code until green
+description: "030: Write failing tests first, then code until green"
 scopes: [chat, edit]
 tags: [testing, tdd]
 priority: 30

--- a/.cursor/rules/050-anti-hallucination.mdc
+++ b/.cursor/rules/050-anti-hallucination.mdc
@@ -1,10 +1,10 @@
 ---
-description: Ten strict guardrails to minimize hallucination
+description: "050: Ten strict guardrails to minimize hallucination"
 globs:
 alwaysApply: false
 ---
 ---
-description: Ten strict guardrails to minimize hallucination
+description: "050: Ten strict guardrails to minimize hallucination"
 scopes: [chat, edit]
 tags: [anti-hallucination, quality]
 priority: 50

--- a/.cursor/rules/060-token-efficiency.mdc
+++ b/.cursor/rules/060-token-efficiency.mdc
@@ -1,5 +1,5 @@
 ---
-description:
+description: "060: Token efficiency and context management"
 globs:
 alwaysApply: false
 ---

--- a/.cursor/rules/090-env-schema.mdc
+++ b/.cursor/rules/090-env-schema.mdc
@@ -1,0 +1,19 @@
+---
+description: "090: Environment variable schema"
+scopes: [chat, edit]
+tags: [env, configuration]
+priority: 90
+alwaysApply: false
+---
+
+## Allowed Environment Variables
+- DATABASE_URL
+- REDIS_URL
+- API_BASE_URL
+- NODE_ENV
+- LOG_LEVEL
+
+**Guidelines**
+- Never request or display secret values.
+- Reference variable *names* only when guiding setup.
+- Use placeholders in examples (e.g., `DATABASE_URL=postgres://...`).

--- a/.cursor/rules/100-python-specific.mdc
+++ b/.cursor/rules/100-python-specific.mdc
@@ -1,10 +1,10 @@
 ---
-description:
+description: "100: Python-specific conventions"
 globs:
 alwaysApply: false
 ---
 ---
-description: Python-specific conventions and patterns
+description: "100: Python-specific conventions and patterns"
 scopes: [chat, edit]
 tags: [python, language-specific]
 priority: 100

--- a/.cursor/rules/105-bash-conventions.mdc
+++ b/.cursor/rules/105-bash-conventions.mdc
@@ -1,5 +1,5 @@
 ---
-description: Shell/Bash scripting conventions and best practices
+description: "105: Shell/Bash scripting conventions and best practices"
 scopes: [chat, edit]
 tags: [shell, bash, scripting, language-specific]
 priority: 105

--- a/.cursor/rules/110-typescript-specific.mdc
+++ b/.cursor/rules/110-typescript-specific.mdc
@@ -1,10 +1,10 @@
 ---
-description: TypeScript/JavaScript patterns and conventions
+description: "110: TypeScript/JavaScript patterns and conventions"
 globs:
 alwaysApply: false
 ---
 ---
-description: TypeScript/JavaScript patterns and conventions
+description: "110: TypeScript/JavaScript patterns and conventions"
 scopes: [chat, edit]
 tags: [typescript, javascript, language-specific]
 priority: 110

--- a/.cursor/rules/200-bugbot-autofix.mdc
+++ b/.cursor/rules/200-bugbot-autofix.mdc
@@ -1,0 +1,15 @@
+---
+description: "200: Responding to BugBot PR comments"
+scopes: [chat]
+tags: [bugbot, automation]
+priority: 200
+alwaysApply: false
+---
+
+Use this rule when the BugBot GitHub app suggests changes in a pull request.
+
+## Workflow
+1. Summarize BugBot's suggestion.
+2. Apply the fix in the referenced file.
+3. Commit with message `fix: <short summary>`.
+4. Reply in the PR with a short confirmation comment.

--- a/.cursor/rules/210-api-design.mdc
+++ b/.cursor/rules/210-api-design.mdc
@@ -4,10 +4,10 @@ globs:
 alwaysApply: false
 ---
 ---
-description: RESTful API design principles and patterns
+description: "210: RESTful API design principles and patterns"
 scopes: [chat, edit]
 tags: [api, design-patterns]
-priority: 200
+priority: 210
 ---
 
 ## 🎯 Template-First Approach

--- a/.cursor/rules/300-commit-msg.mdc
+++ b/.cursor/rules/300-commit-msg.mdc
@@ -1,0 +1,17 @@
+---
+description: "300: Conventional commit messages"
+scopes: [chat]
+tags: [git, changelog]
+priority: 300
+alwaysApply: false
+---
+
+When asked to create a commit message, use the Conventional Commits style.
+Include a short changelog line after the message when appropriate.
+
+Example:
+```
+feat: add login API
+
+Adds new authentication endpoint for mobile clients.
+```

--- a/.cursor/rules/310-security-audit.mdc
+++ b/.cursor/rules/310-security-audit.mdc
@@ -1,13 +1,13 @@
 ---
-description:
+description: "310: Security audit"
 globs:
 alwaysApply: false
 ---
 ---
-description: Security audit checklist and secure coding practices
+description: "310: Security audit checklist and secure coding practices"
 scopes: [chat, edit]
 tags: [security, audit]
-priority: 300
+priority: 310
 ---
 
 ## 🔒 Security Audit Standards

--- a/.cursor/rules/400-reactive-storage.mdc
+++ b/.cursor/rules/400-reactive-storage.mdc
@@ -1,0 +1,15 @@
+---
+description: "400: React reactive storage patterns"
+scopes: [chat, edit]
+tags: [react, nextjs, state]
+priority: 400
+alwaysApply: false
+---
+
+Guidelines for managing shared state with React context and hooks.
+
+## Usage
+- Create a `StorageProvider` using `createContext`.
+- Expose a custom hook `useStorage()` for consumers.
+- Persist data with `useEffect` to sync to `localStorage` when needed.
+- Keep provider logic minimal and testable.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,4 +69,12 @@ jobs:
             fi
           done
           
-          echo "✅ All rule files follow naming convention" 
+          echo "✅ All rule files follow naming convention"
+      - name: Check @references
+        run: |
+          grep -R --no-line-number '@' .cursor/rules/*.mdc \
+            | sed 's/.*@//' \
+            | while read path; do
+              [ -z "$path" ] && continue
+              [ -e "$path" ] || { echo "$path missing"; exit 1; }
+            done

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "workbench.editorAssociations": {
+    "*.mdc": "default"
+  }
+}

--- a/FAQ.md
+++ b/FAQ.md
@@ -11,7 +11,7 @@ Cursor loads rules in this order:
 Example:
 - `001-base.mdc` (priority: 1) loads first
 - `050-anti-hallucination.mdc` (priority: 50) can override base rules
-- `300-security-audit.mdc` (priority: 300) has highest precedence
+- `310-security-audit.mdc` (priority: 310) has highest precedence
 
 ### What are `scopes` and how do I use them?
 Scopes control when rules are applied:

--- a/README.md
+++ b/README.md
@@ -6,11 +6,16 @@
 
 - ✅ **YAML Linting** - GitHub Actions automatically validate rule syntax
 - ✅ **Scopes & Tags** - Modern Cursor features for selective rule enabling
-- ✅ **Shell Support** - Dedicated Bash/Shell scripting rules (105-shell-specific.mdc)
+- ✅ **Shell Support** - Dedicated Bash/Shell scripting rules (105-bash-conventions.mdc)
 - ✅ **FAQ & Examples** - Comprehensive documentation and `.cursorignore` examples
 - ✅ **Enhanced Priority System** - Clear rule precedence with priority fields
 
 ## 🚀 Quick Start
+
+### One-Line Install
+```bash
+curl -s https://raw.githubusercontent.com/n0rvyn/cursor-rules/main/install-cursor-rules.sh | bash
+```
 
 ### 1. Copy Configuration
 ```bash
@@ -66,11 +71,15 @@ cp -r .cursor your-project/
 │   │   ├── 030-test-driven.mdc # TDD patterns
 │   │   ├── 050-anti-hallucination.mdc # AI protection strategies
 │   │   ├── 060-token-efficiency.mdc # Performance optimization
+│   │   ├── 090-env-schema.mdc      # Document environment variable names
 │   │   ├── 100-python-specific.mdc # Python templates & patterns
-│   │   ├── 105-shell-specific.mdc # Shell/Bash best practices
+│   │   ├── 105-bash-conventions.mdc # Shell/Bash best practices
 │   │   ├── 110-typescript-specific.mdc # TypeScript/React patterns
-│   │   ├── 200-api-design.mdc  # API development standards
-│   │   └── 300-security-audit.mdc # Security & compliance
+│   │   ├── 200-bugbot-autofix.mdc  # BugBot PR workflow
+│   │   ├── 210-api-design.mdc  # API development standards
+│   │   ├── 300-commit-msg.mdc  # Conventional commit guidance
+│   │   ├── 310-security-audit.mdc # Security & compliance
+│   │   └── 400-reactive-storage.mdc # React state patterns
 │   └── team-rules-examples/    # Team collaboration templates
 │       ├── enterprise/
 │       │   └── governance/
@@ -99,13 +108,15 @@ cp -r .cursor your-project/
 - **010-checklist.mdc**: Automatic task list maintenance
 - **020-safety.mdc**: Basic error prevention
 - **050-anti-hallucination.mdc**: Advanced AI protection strategies
+- **060-token-efficiency.mdc**: Performance optimization
+- **090-env-schema.mdc**: Document allowed environment variables
 
 ### Language-Specific Rules (Optional)
 - **100-python.mdc**: Type hints, async/await, pytest patterns
-- **105-shell-specific.mdc**: Shell/Bash scripting best practices, error handling
+- **105-bash-conventions.mdc**: Shell/Bash scripting best practices, error handling
 - **110-typescript.mdc**: Strict typing, React patterns, Jest testing
-- **200-api-design.mdc**: RESTful conventions, OpenAPI documentation
-- **300-security.mdc**: Security best practices and compliance
+- **210-api-design.mdc**: RESTful conventions, OpenAPI documentation
+- **300-commit-msg.mdc**: Conventional commit guidance
 
 ### Modern Rule Features
 All rules now include:
@@ -181,12 +192,15 @@ alwaysApply: true                   # Always vs conditional activation
 
 ### Language-Specific Rules (100-199)
 - **100-python-specific.mdc**: Template-first development, type hints, async patterns, testing conventions
-- **105-shell-specific.mdc**: Bash best practices, error handling, security considerations, shellcheck compliance
+- **105-bash-conventions.mdc**: Bash best practices, error handling, security considerations, shellcheck compliance
 - **110-typescript-specific.mdc**: Template-driven React/Express patterns, strict TypeScript, modern frameworks
 
 ### Domain-Specific Rules (200-399)
-- **200-api-design.mdc**: Template-first API development, RESTful conventions, OpenAPI documentation
-- **300-security-audit.mdc**: Comprehensive security standards, best practices, compliance checklists
+- **200-bugbot-autofix.mdc**: Handle BugBot PR comments
+- **210-api-design.mdc**: Template-first API development, RESTful conventions, OpenAPI documentation
+- **300-commit-msg.mdc**: Conventional commit guidance
+- **310-security-audit.mdc**: Comprehensive security standards, best practices, compliance checklists
+- **400-reactive-storage.mdc**: React context and state patterns
 
 ### Template Library (`/templates/`)
 - **express-service.ts**: Complete Express service with validation, error handling, TypeScript types

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,11 +6,16 @@
 
 - ✅ **YAML 语法检查** - GitHub Actions 自动验证规则语法
 - ✅ **作用域和标签** - 现代 Cursor 功能，支持选择性规则启用
-- ✅ **Shell 支持** - 专门的 Bash/Shell 脚本规则 (105-shell-specific.mdc)
+- ✅ **Shell 支持** - 专门的 Bash/Shell 脚本规则 (105-bash-conventions.mdc)
 - ✅ **FAQ 和示例** - 全面的文档和 `.cursorignore` 示例
 - ✅ **增强优先级系统** - 清晰的规则优先级字段
 
 ## 🚀 快速开始
+
+### 一行安装
+```bash
+curl -s https://raw.githubusercontent.com/n0rvyn/cursor-rules/main/install-cursor-rules.sh | bash
+```
 
 ### 1. 复制配置
 ```bash
@@ -64,11 +69,15 @@ cp -r .cursor your-project/
 │   │   ├── 030-test-driven.mdc # TDD 模式
 │   │   ├── 050-anti-hallucination.mdc # AI 保护策略
 │   │   ├── 060-token-efficiency.mdc # 性能优化
+│   │   ├── 090-env-schema.mdc      # 环境变量名称文档
 │   │   ├── 100-python-specific.mdc # Python 模板和模式
-│   │   ├── 105-shell-specific.mdc # Shell/Bash 最佳实践
+│   │   ├── 105-bash-conventions.mdc # Shell/Bash 最佳实践
 │   │   ├── 110-typescript-specific.mdc # TypeScript/React 模式
-│   │   ├── 200-api-design.mdc  # API 开发标准
-│   │   └── 300-security-audit.mdc # 安全和合规性
+│   │   ├── 200-bugbot-autofix.mdc  # BugBot PR 工作流
+│   │   ├── 210-api-design.mdc  # API 开发标准
+│   │   ├── 300-commit-msg.mdc  # 约定式提交
+│   │   ├── 310-security-audit.mdc # 安全和合规性
+│   │   └── 400-reactive-storage.mdc # React 状态模式
 │   └── team-rules-examples/    # 团队协作模板
 │       ├── enterprise/
 │       │   └── governance/
@@ -97,13 +106,15 @@ cp -r .cursor your-project/
 - **010-checklist.mdc**: 自动任务列表维护
 - **020-safety.mdc**: 基本错误预防
 - **050-anti-hallucination.mdc**: 高级 AI 保护策略
+- **060-token-efficiency.mdc**: 性能优化
+- **090-env-schema.mdc**: 环境变量名称文档
 
 ### 语言特定规则（可选）
 - **100-python.mdc**: 类型提示、async/await、pytest 模式
-- **105-shell-specific.mdc**: Shell/Bash 脚本最佳实践、错误处理
+- **105-bash-conventions.mdc**: Shell/Bash 脚本最佳实践、错误处理
 - **110-typescript.mdc**: 严格类型、React 模式、Jest 测试
-- **200-api-design.mdc**: RESTful 约定、OpenAPI 文档
-- **300-security.mdc**: 安全最佳实践和合规性
+- **210-api-design.mdc**: RESTful 约定、OpenAPI 文档
+- **300-commit-msg.mdc**: 约定式提交信息指南
 
 ### 现代规则功能
 所有规则现在包括：
@@ -183,12 +194,15 @@ alwaysApply: true                   # 始终 vs 条件激活
 
 ### 语言特定规则 (100-199)
 - **100-python-specific.mdc**: 模板优先开发、类型提示、异步模式、测试约定
-- **105-shell-specific.mdc**: Bash 最佳实践、错误处理、安全考虑、shellcheck 合规性
+- **105-bash-conventions.mdc**: Bash 最佳实践、错误处理、安全考虑、shellcheck 合规性
 - **110-typescript-specific.mdc**: 模板驱动 React/Express 模式、严格 TypeScript、现代框架
 
 ### 领域特定规则 (200-399)
-- **200-api-design.mdc**: 模板优先 API 开发、RESTful 约定、OpenAPI 文档
-- **300-security-audit.mdc**: 综合安全标准、最佳实践、合规性清单
+- **200-bugbot-autofix.mdc**: 处理 BugBot PR 评论
+- **210-api-design.mdc**: 模板优先 API 开发、RESTful 约定、OpenAPI 文档
+- **300-commit-msg.mdc**: 约定式提交信息指南
+- **310-security-audit.mdc**: 综合安全标准、最佳实践、合规性清单
+- **400-reactive-storage.mdc**: React 状态管理模式
 
 ### 模板库 (`/templates/`)
 - **express-service.ts**: 完整的 Express 服务，包含验证、错误处理、TypeScript 类型


### PR DESCRIPTION
## Summary
- rename shell rule to `105-bash-conventions.mdc`
- introduce new advanced rules: environment schema, BugBot workflow, commit message style and React storage
- renumber API and security rules
- add VS Code settings hack and install badge
- update GitHub Actions to check broken references

## Testing
- `pip install yamllint`
- `for file in $(find .cursor/rules -name '*.mdc'); do sed -n '1,/^---$/p' "$file" | sed '1d;$d' > temp_yaml.yml; yamllint temp_yaml.yml || exit 1; rm temp_yaml.yml; done`

------
https://chatgpt.com/codex/tasks/task_e_68551e2a287c8328b47ddef7d4424cc7