### PR TITLE
Add Swift and iOS project rules

### DIFF
--- a/.cursor/rules/120-swift-specific.mdc
+++ b/.cursor/rules/120-swift-specific.mdc
@@ -1,0 +1,37 @@
+---
+description: "120: Swift-specific conventions"
+globs:
+  - "**/*.swift"
+alwaysApply: false
+---
+---
+description: "120: Swift language patterns and iOS best practices"
+scopes: [chat, edit]
+tags: [swift, ios, language-specific]
+priority: 120
+---
+
+## \ud83c\udf1f Swift Fundamentals
+- Prefer SwiftUI for new UI code
+- Use Swift Package Manager for dependencies
+- Keep functions short and focused on a single task
+- Favor `struct` over `class` when possible
+- Use protocol-oriented programming principles
+- Document public APIs with `///` comments
+
+## \ud83d\udd04 Async & Concurrency
+- Use `async/await` for asynchronous code (Swift 5.5+)
+- Avoid blocking the main thread; offload work to background queues
+- Leverage `Task` and `TaskGroup` for structured concurrency
+- Cancel tasks using `Task` cancellation when appropriate
+
+## \ud83d\udeaa Error Handling
+- Define custom `Error` enums for meaningful error cases
+- Propagate errors with `throws` and handle using `do/catch`
+- Avoid silently ignoring errors
+
+## \ud83d\udcdd Testing
+- Use XCTest for unit tests
+- Aim for high coverage of business logic
+- Inject dependencies for easier mocking
+- Run tests via `xcodebuild test` or Xcode CI pipelines

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - ✅ **YAML Linting** - GitHub Actions automatically validate rule syntax
 - ✅ **Scopes & Tags** - Modern Cursor features for selective rule enabling
 - ✅ **Shell Support** - Dedicated Bash/Shell scripting rules (105-bash-conventions.mdc)
+- ✅ **Swift/iOS Support** - Dedicated Swift rules (120-swift-specific.mdc) and iPhone project template
 - ✅ **FAQ & Examples** - Comprehensive documentation and `.cursorignore` examples
 - ✅ **Enhanced Priority System** - Clear rule precedence with priority fields
 
@@ -75,6 +76,7 @@ cp -r .cursor your-project/
 │   │   ├── 100-python-specific.mdc # Python templates & patterns
 │   │   ├── 105-bash-conventions.mdc # Shell/Bash best practices
 │   │   ├── 110-typescript-specific.mdc # TypeScript/React patterns
+│   │   ├── 120-swift-specific.mdc # Swift/iOS patterns
 │   │   ├── 200-bugbot-autofix.mdc  # BugBot PR workflow
 │   │   ├── 210-api-design.mdc  # API development standards
 │   │   ├── 300-commit-msg.mdc  # Conventional commit guidance
@@ -85,9 +87,13 @@ cp -r .cursor your-project/
 │       │   └── governance/
 │       │       └── approval-process.mdc
 │       ├── languages/
-│       │   └── go/
-│       │       └── go-specific.mdc
+│       │   ├── go/
+│       │   │   └── go-specific.mdc
+│       │   └── swift/
+│       │       └── swift-specific.mdc
 │       ├── projects/
+│       │   ├── ios-app/
+│       │   │   └── ios-project.mdc
 │       │   └── web-api/
 │       │       └── api-project.mdc
 │       ├── README.md
@@ -115,6 +121,7 @@ cp -r .cursor your-project/
 - **100-python.mdc**: Type hints, async/await, pytest patterns
 - **105-bash-conventions.mdc**: Shell/Bash scripting best practices, error handling
 - **110-typescript.mdc**: Strict typing, React patterns, Jest testing
+- **120-swift.mdc**: Swift language patterns, async concurrency, XCTest guidelines
 - **210-api-design.mdc**: RESTful conventions, OpenAPI documentation
 - **300-commit-msg.mdc**: Conventional commit guidance
 
@@ -474,6 +481,12 @@ cp templates/python-service.py your-project/templates/
 cp .cursor/rules/110-typescript-specific.mdc your-project/.cursor/rules/
 cp templates/react-component.tsx your-project/templates/
 cp templates/express-service.ts your-project/templates/
+```
+
+### Swift Projects
+```bash
+# Copy Swift-specific rules
+cp .cursor/rules/120-swift-specific.mdc your-project/.cursor/rules/
 ```
 
 ## 🔍 Troubleshooting

--- a/README.zh.md
+++ b/README.zh.md
@@ -7,6 +7,7 @@
 - ✅ **YAML 语法检查** - GitHub Actions 自动验证规则语法
 - ✅ **作用域和标签** - 现代 Cursor 功能，支持选择性规则启用
 - ✅ **Shell 支持** - 专门的 Bash/Shell 脚本规则 (105-bash-conventions.mdc)
+- ✅ **Swift/iOS 支持** - Swift 语言规则 (120-swift-specific.mdc) 及 iPhone 项目模板
 - ✅ **FAQ 和示例** - 全面的文档和 `.cursorignore` 示例
 - ✅ **增强优先级系统** - 清晰的规则优先级字段
 
@@ -73,6 +74,7 @@ cp -r .cursor your-project/
 │   │   ├── 100-python-specific.mdc # Python 模板和模式
 │   │   ├── 105-bash-conventions.mdc # Shell/Bash 最佳实践
 │   │   ├── 110-typescript-specific.mdc # TypeScript/React 模式
+│   │   ├── 120-swift-specific.mdc # Swift/iOS 模式
 │   │   ├── 200-bugbot-autofix.mdc  # BugBot PR 工作流
 │   │   ├── 210-api-design.mdc  # API 开发标准
 │   │   ├── 300-commit-msg.mdc  # 约定式提交
@@ -83,9 +85,13 @@ cp -r .cursor your-project/
 │       │   └── governance/
 │       │       └── approval-process.mdc
 │       ├── languages/
-│       │   └── go/
-│       │       └── go-specific.mdc
+│       │   ├── go/
+│       │   │   └── go-specific.mdc
+│       │   └── swift/
+│       │       └── swift-specific.mdc
 │       ├── projects/
+│       │   ├── ios-app/
+│       │   │   └── ios-project.mdc
 │       │   └── web-api/
 │       │       └── api-project.mdc
 │       ├── README.md
@@ -196,6 +202,7 @@ alwaysApply: true                   # 始终 vs 条件激活
 - **100-python-specific.mdc**: 模板优先开发、类型提示、异步模式、测试约定
 - **105-bash-conventions.mdc**: Bash 最佳实践、错误处理、安全考虑、shellcheck 合规性
 - **110-typescript-specific.mdc**: 模板驱动 React/Express 模式、严格 TypeScript、现代框架
+- **120-swift-specific.mdc**: Swift 模式、异步并发、XCTest 指南
 
 ### 领域特定规则 (200-399)
 - **200-bugbot-autofix.mdc**: 处理 BugBot PR 评论
@@ -476,6 +483,12 @@ cp templates/python-service.py your-project/templates/
 cp .cursor/rules/110-typescript-specific.mdc your-project/.cursor/rules/
 cp templates/react-component.tsx your-project/templates/
 cp templates/express-service.ts your-project/templates/
+```
+
+### Swift 项目
+```bash
+# 复制 Swift 特定规则
+cp .cursor/rules/120-swift-specific.mdc your-project/.cursor/rules/
 ```
 
 ## 🔍 故障排除

--- a/team-rules-examples/README.md
+++ b/team-rules-examples/README.md
@@ -44,9 +44,13 @@ cursor-team-rules/
 ├── shared/
 │   └── 010-security-baseline.mdc    # Security requirements for all projects
 ├── languages/
-│   └── go/
-│       └── go-specific.mdc          # Go language conventions
+│   ├── go/
+│   │   └── go-specific.mdc          # Go language conventions
+│   └── swift/
+│       └── swift-specific.mdc       # Swift language conventions
 ├── projects/
+│   ├── ios-app/
+│   │   └── ios-project.mdc          # iPhone app project rules
 │   └── web-api/
 │       └── api-project.mdc          # Web API specific rules
 └── enterprise/
@@ -60,9 +64,11 @@ cursor-team-rules/
 - **Go**: `languages/go/go-specific.mdc` - Idiomatic Go patterns, error handling, concurrency
 - **Python**: Already in core rules as `100-python-specific.mdc`
 - **TypeScript**: Already in core rules as `110-typescript-specific.mdc`
+- **Swift**: `languages/swift/swift-specific.mdc` - SwiftLint, SPM, XCTest patterns
 
 ### Project-Type Rules
 - **Web API**: `projects/web-api/api-project.mdc` - RESTful patterns, OpenAPI docs
+- **iOS App**: `projects/ios-app/ios-project.mdc` - Xcode workspace, SwiftUI guidelines
 - **Security**: `shared/010-security-baseline.mdc` - Basic security requirements
 
 ### Enterprise Features

--- a/team-rules-examples/languages/swift/swift-specific.mdc
+++ b/team-rules-examples/languages/swift/swift-specific.mdc
@@ -1,0 +1,20 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+## \ud83d\udc8c Swift 规则
+
+### 代码风格
+- 使用 SwiftLint 保持一致的编码风格
+- 默认使用 Swift Package Manager 作为依赖管理工具
+- 对可选值使用 `guard let` 或 `if let` 解包
+- 对外公开的 API 使用 `///` 风格注释
+
+### 错误处理
+- 使用 `do/catch` 处理抛出的错误
+- 自定义 `Error` 枚举以提供清晰错误类型
+
+### 测试
+- 使用 XCTest 编写单元测试
+- 保持测试覆盖率在 80% 以上

--- a/team-rules-examples/projects/ios-app/ios-project.mdc
+++ b/team-rules-examples/projects/ios-app/ios-project.mdc
@@ -1,0 +1,28 @@
+---
+description:
+globs:
+alwaysApply: false
+---
+## \ud83d\udcf1 iPhone App Xcode Project Rules
+
+### 项目结构
+- 使用 `.xcworkspace` 管理依赖和示例项目
+- 按功能模块组织代码，保持文件夹清晰
+- 将资源放入 `Resources` 目录，并使用资产目录管理
+
+### 构建设置
+- 在 Xcode 中启用 `Treat warnings as errors`
+- 使用 Swift Package Manager 管理第三方库
+- 开启严格的并发检查
+
+### UI 准则
+- 新界面优先使用 SwiftUI 实现
+- 支持明暗模式和动态字体
+- 遵循 Apple HIG 以确保无障碍访问
+- 使用 SF Symbols 替代自定义图标
+
+### CI/CD
+- 使用 `xcodebuild` 进行命令行构建
+- 导出 IPA 时使用 `xcodebuild -exportArchive`
+- 通过自动签名或 fastlane match 管理证书
+- 在 CI 流水线中运行单元测试和 UI 测试


### PR DESCRIPTION
## Summary
- add Swift language rule `120-swift-specific.mdc`
- add iOS app project example rule
- document Swift/iOS support in both READMEs
- include Swift and iOS paths in team examples

## Testing
- `python3 -m pip install yamllint`
- `find .cursor/rules -name "*.mdc" | while read f; do ... yamllint ...; done`

------
https://chatgpt.com/codex/tasks/task_e_68553d2a4d3c8328b11fa65906550b21