### PR TITLE
Improve docs for rule precedence and automation

### DIFF
--- a/.cursor/rules/210-api-design.mdc
+++ b/.cursor/rules/210-api-design.mdc
@@ -3,6 +3,7 @@ description: "210: RESTful API design principles and patterns"
 scopes: [chat, edit]
 tags: [api, design-patterns]
 priority: 210
+---
 ## 🎯 Template-First Approach
 - **Express Services**: Use skeleton from @templates/express-service.ts for new API endpoints
 - **Python Services**: Use pattern from @templates/python-service.py for async service classes

--- a/FAQ.md
+++ b/FAQ.md
@@ -124,6 +124,7 @@ globs:
 ### How do I share rules with my team?
 1. **Fork this repository**
 2. **Customize rules for your needs**
+   - Copy templates from the `templates/` directory for common patterns
 3. **Share the installation script:**
    ```bash
    curl -sL https://raw.githubusercontent.com/YOUR_USERNAME/cursor-rules/main/install-cursor-rules.sh | bash
@@ -132,6 +133,7 @@ globs:
 ### What's the difference between `alwaysApply` and regular rules?
 - `alwaysApply: true` - Rule is active in all contexts
 - Regular rules - Only active when file patterns match `globs`
+- Priority still controls which rule wins when multiple `alwaysApply` rules apply
 
 ### How do I debug rule conflicts?
 1. **Check rule loading order:**
@@ -150,4 +152,8 @@ globs:
 
 ---
 
-> 💡 **Tip**: Start with the base rules and gradually add language-specific ones. Don't enable everything at once! 
+> 💡 **Tip**: Start with the base rules and gradually add language-specific ones. Don't enable everything at once!
+
+### How do I automate rule checks?
+1. Install `pre-commit` and add hooks for linting and tests.
+2. Mirror the same commands in your CI pipeline so every push runs the checks.

--- a/README.md
+++ b/README.md
@@ -164,6 +164,34 @@ alwaysApply: true                   # Always vs conditional activation
 | **Agent Requested** | `description` required | AI decides based on description |
 | **Manual** | Default | Only when explicitly called with `@ruleName` |
 
+**Examples**
+
+```mdc
+---
+description: "Always enforce lint"  # Always
+alwaysApply: true
+---
+```
+
+```mdc
+---
+description: "Attach for UI components"  # Auto attached
+globs: ["src/components/**/*.tsx"]
+---
+```
+
+```mdc
+---
+description: "Refactor suggestions"  # Agent requested
+---
+```
+
+```mdc
+---
+description: "Internal rule, call with @my-rule"  # Manual
+---
+```
+
 **💡 Best Practices:**
 - Keep rules under 500 lines for optimal performance
 - Use specific, actionable language
@@ -221,6 +249,9 @@ alwaysApply: true                   # Always vs conditional activation
 - **Scope Control**: `alwaysApply: true` for critical rules
 - **Contextual Application**: Rules activate based on file type and project context
 - **Two-Stage Activation**: Rules are first injected into context, then AI decides relevance based on description
+- **Precedence Note**: `alwaysApply` rules are always injected, but priority still determines the order when multiple rules apply
+
+When two rules apply to the same file, the one with the lower numeric priority is inserted first. `alwaysApply` simply ensures a rule is active; it does not override priority.
 
 ### Advanced Rule Techniques
 
@@ -263,6 +294,12 @@ project/
     .cursor/rules/        # Frontend-specific rules
 ```
 
+#### Extending and Customizing Rules
+1. Copy an existing rule from `.cursor/rules` and adjust the front matter.
+2. Reference reusable code under `templates/` with `@templates/<file>`.
+3. Increase the `priority` number to override default behavior.
+4. Commit the new rule so it is shared with your team.
+
 #### Combined Rule Types
 Rules can be both auto-attached AND agent-requested:
 ```mdc
@@ -295,7 +332,8 @@ Our rule system implements research-backed techniques to reduce AI errors:
 
 ### Automated Safeguards
 - **DEV_CHECKLIST.md**: Automatic task tracking and completion verification
-- **Git Integration**: Pre-commit hooks prevent incomplete work from being committed
+- **Git Integration**: Pre-commit hooks run lint and tests before each commit
+- **CI Pipelines**: Mirror the pre-commit checks in your build server
 - **Progress Checkpoints**: Structured workflow prevents scope creep
 
 ## 🚀 Advanced Techniques


### PR DESCRIPTION
## Summary
- clarify how `alwaysApply` interacts with rule priority
- add rule type examples with code snippets
- document how to extend and customize rules
- expand automated safeguard section with CI hooks
- update FAQ to mention templates, alwaysApply behavior, and automation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b8d306be483288f0b27d35740c0b1